### PR TITLE
fix: fix complex cargo struct project build error

### DIFF
--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -57,7 +57,7 @@ function mlua.run(rockspec, no_install)
         cmd_sep = "&&"
     end
 
-    table.insert(cmd, "cargo build --release --features " .. table.concat(features, ","))
+    table.insert(cmd, "CARGO_TARGET_DIR=. cargo build --release --features " .. table.concat(features, ","))
     if not fs.execute(table.concat(cmd, cmd_sep)) then
         return nil, "Failed building."
     end

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -57,7 +57,7 @@ function mlua.run(rockspec, no_install)
         cmd_sep = "&&"
     end
 
-    table.insert(cmd, "CARGO_TARGET_DIR=. cargo build --release --features " .. table.concat(features, ","))
+    table.insert(cmd, "CARGO_TARGET_DIR=./target cargo build --release --features " .. table.concat(features, ","))
     if not fs.execute(table.concat(cmd, cmd_sep)) then
         return nil, "Failed building."
     end


### PR DESCRIPTION
use the current directory as the cargo build target. If you want to know more information, please check https://github.com/apache/incubator-opendal/pull/2558