### PR TITLE
Update to mlua v0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ dependencies = {
 
 build = {
     type = "rust-mlua",
+
     modules = {
         -- Native library expected in `<target_path>/release/libmy_module.so` (linux; uses right name on macos/windows)
         "my_module",
@@ -42,7 +43,8 @@ build = {
 
     -- Optional: if set to `false` pass `--no-default-features` to cargo
     default_features = false,
+
     -- Optional: pass additional features
-    features = {"extra_feature"}
+    features = {"extra", "features"}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,5 +39,10 @@ build = {
 
     -- Optional: target_path if cargo "target" directory not in the module root
     target_path = "path/to/cargo/target/directory"
+
+    -- Optional: if set to `false` pass `--no-default-features` to cargo
+    default_features = false,
+    -- Optional: pass additional features
+    features = {"extra_feature"}
 }
 ```

--- a/luarocks-build-rust-mlua-0.2.0-1.rockspec
+++ b/luarocks-build-rust-mlua-0.2.0-1.rockspec
@@ -1,10 +1,10 @@
 rockspec_format = "3.0"
 package = "luarocks-build-rust-mlua"
-version = "0.1.2-1"
+version = "0.2.0-1"
 
 source = {
     url = "git+https://github.com/khvzak/luarocks-build-rust-mlua",
-    tag = "0.1.2",
+    tag = "0.2.0",
 }
 
 description = {

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -30,14 +30,18 @@ function mlua.run(rockspec, no_install)
     end
 
     local cmd = {"cargo build --release"}
-    -- Check if default features not required
-    if rockspec.build and rockspec.build.default_features == false then
-        table.insert(cmd, "--no-default-features")
-    end
-    -- Add additional features
-    if rockspec.build and type(rockspec.build.features) == "table" then
-        for _, feature in ipairs(rockspec.build.features) do
-            table.insert(features, feature)
+    if rockspec.build then
+        -- Check if default features not required
+        if rockspec.build.default_features == false then
+            table.insert(cmd, "--no-default-features")
+        end
+        -- Add additional features
+        if type(rockspec.build.features) == "table" then
+            for _, feature in ipairs(rockspec.build.features) do
+                table.insert(features, feature)
+            end
+        elseif type(rockspec.build.features) == "string" then
+            table.insert(features, rockspec.build.features)
         end
     end
     table.insert(cmd, "--features")

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -15,12 +15,9 @@ function mlua.run(rockspec, no_install)
 
     local features = {}
     local lua_version = cfg.lua_version
-    local variables = rockspec.variables
 
     -- Activate features depending on Lua version
-    if (cfg.cache or {}).luajit_version ~= nil then
-        table.insert(features, "luajit")
-    elseif lua_version == "5.4" then
+    if lua_version == "5.4" then
         table.insert(features, "lua54")
     elseif lua_version == "5.3" then
         table.insert(features, "lua53")
@@ -32,33 +29,8 @@ function mlua.run(rockspec, no_install)
         return nil, "Lua version " .. lua_version .. " is not supported"
     end
 
-    local cmd, cmd_sep = {}, " "
-    local lua_incdir, lua_h = variables.LUA_INCDIR, "lua.h"
-    local found_lua_h = fs.exists(dir.path(lua_incdir, lua_h))
-    if not cfg.is_platform("windows") then
-        -- If lua.h does not exists, add "vendored" feature (probably this is impossible case)
-        if found_lua_h then
-            table.insert(cmd, "LUA_INC=" .. variables.LUA_INCDIR)
-        else
-            table.insert(features, "vendored")
-        end
-    else
-        -- For windows we must ensure that lua.h exists
-        if not found_lua_h then
-            return nil, "Lua header file " .. lua_h .. " not found (looked in " .. lua_incdir .. "). \n" ..
-                "You need to install the Lua development package for your system."
-        end
-        local lualib = variables.LUALIB
-        lualib = string.gsub(lualib, "%.lib$", "")
-        lualib = string.gsub(lualib, "%.dll$", "")
-        table.insert(cmd, "SET LUA_INC=" .. variables.LUA_INCDIR)
-        table.insert(cmd, "SET LUA_LIB=" .. variables.LUA_LIBDIR)
-        table.insert(cmd, "SET LUA_LIB_NAME=" .. lualib)
-        cmd_sep = "&&"
-    end
-
-    table.insert(cmd, "cargo build --release --features " .. table.concat(features, ","))
-    if not fs.execute(table.concat(cmd, cmd_sep)) then
+    local cmd = "cargo build --release --features " .. table.concat(features, ",")
+    if not fs.execute(cmd) then
         return nil, "Failed building."
     end
 

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -29,8 +29,21 @@ function mlua.run(rockspec, no_install)
         return nil, "Lua version " .. lua_version .. " is not supported"
     end
 
-    local cmd = "cargo build --release --features " .. table.concat(features, ",")
-    if not fs.execute(cmd) then
+    local cmd = {"cargo build --release"}
+    -- Check if default features not required
+    if rockspec.build and rockspec.build.default_features == false then
+        table.insert(cmd, "--no-default-features")
+    end
+    -- Add additional features
+    if rockspec.build and type(rockspec.build.features) == "table" then
+        for _, feature in ipairs(rockspec.build.features) do
+            table.insert(features, feature)
+        end
+    end
+    table.insert(cmd, "--features")
+    table.insert(cmd, table.concat(features, ","))
+
+    if not fs.execute(table.concat(cmd, " ")) then
         return nil, "Failed building."
     end
 


### PR DESCRIPTION
This version does not require Lua libs or headers (on Windows) when building modules