### PR TITLE
Re-enable support for LuaRocks 3.1.x

### DIFF
--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -25,7 +25,7 @@ function mlua.run(rockspec, no_install)
     elseif lua_version == "5.2" then
         table.insert(features, "lua52")
     elseif lua_version == "5.1" then
-        if util.get_luajit_version() ~= nil then
+        if util.get_luajit_version and util.get_luajit_version() ~= nil then
             table.insert(features, "luajit")
         else
             table.insert(features, "lua51")

--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -25,7 +25,8 @@ function mlua.run(rockspec, no_install)
     elseif lua_version == "5.2" then
         table.insert(features, "lua52")
     elseif lua_version == "5.1" then
-        if util.get_luajit_version and util.get_luajit_version() ~= nil then
+        -- cfg.luajit_version exists in 3.1.x but not 3.9.x
+        if (util.get_luajit_version and util.get_luajit_version() ~= nil) or cfg.luajit_version then
             table.insert(features, "luajit")
         else
             table.insert(features, "lua51")


### PR DESCRIPTION
The API used to detect LuaJIT did not exist in LuaRocks 3.1.x (which is meaningful because it is still shipped in Ubuntu LTS releases). Since the function doesn't exist it throws an error, not just under LuaJIT but when trying to build any rock for Lua 5.1. The older API doesn't exist in current versions, so we're kind of stuck trying two things and trying not to raise any Lua errors along the way.

This should make mlua builds under old LuaRocks tooling work again targeting Lua 5.1. It currently does work for Lua 5.2 or greater, so this is the only thing holding it back.