### PR TITLE
fix: mutable loop variable for Lua 5.5 support

### DIFF
--- a/src/luarocks/build/rust-mlua.lua
+++ b/src/luarocks/build/rust-mlua.lua
@@ -102,7 +102,8 @@ function mlua.run(rockspec, no_install)
             local luadir = path.lua_dir(rockspec.name, rockspec.version)
 
             fs.make_dir(dir.dir_name(luadir))
-            for from, to in pairs(rockspec.build.include) do
+            for k, to in pairs(rockspec.build.include) do
+                local from = k
                 if type(from) == "number" then
                     from = to
                 end


### PR DESCRIPTION
There's still a leftover loop variable assignment that fails when building with Lua 5.5.